### PR TITLE
Update teams.inc.php

### DIFF
--- a/include/staff/teams.inc.php
+++ b/include/staff/teams.inc.php
@@ -4,7 +4,7 @@ if(!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access
 $qs = array();
 $sortOptions=array(
         'name' => 'name',
-        'status' => 'isenabled',
+        'status' => 'flags',
         'members' => 'members_count',
         'lead' => 'lead__lastname',
         'created' => 'created',


### PR DESCRIPTION
The sorting by status on the Admin Teams page did not work.  The problem is that the code sorts status by calling for an ordering on the 'isenabled' field which does not exist, it is actually called 'flags'.

